### PR TITLE
docs: add getting started page

### DIFF
--- a/site/.vitepress/config.ts
+++ b/site/.vitepress/config.ts
@@ -24,10 +24,6 @@ export default defineConfig({
       { text: "Introduction", link: "/introduction" },
       { text: "Getting Started", link: "/getting-started" },
       {
-        text: "Packages Overview",
-        link: "/packages/overview",
-      },
-      {
         text: "Using Smart Accounts",
         base: "/smart-accounts",
         items: [
@@ -55,6 +51,10 @@ export default defineConfig({
           { text: "Batching Transactions", link: "/batching-transactions" },
           { text: "Transferring Ownership", link: "/transferring-ownership" },
         ],
+      },
+      {
+        text: "Packages Overview",
+        link: "/packages/overview",
       },
       // Per Package docs
       {

--- a/site/.vitepress/config.ts
+++ b/site/.vitepress/config.ts
@@ -24,6 +24,10 @@ export default defineConfig({
       { text: "Introduction", link: "/introduction" },
       { text: "Getting Started", link: "/getting-started" },
       {
+        text: "Packages Overview",
+        link: "/packages/overview",
+      },
+      {
         text: "Using Smart Accounts",
         base: "/smart-accounts",
         items: [
@@ -51,10 +55,6 @@ export default defineConfig({
           { text: "Batching Transactions", link: "/batching-transactions" },
           { text: "Transferring Ownership", link: "/transferring-ownership" },
         ],
-      },
-      {
-        text: "Packages Overview",
-        link: "/packages/overview",
       },
       // Per Package docs
       {

--- a/site/getting-started.md
+++ b/site/getting-started.md
@@ -16,7 +16,7 @@ head:
 
 This guide will help you get started with Account Kit by setting up your environment, creating a Light Account (a type of smart account implementation), and sending a User Operation from it. By the end of this guide, you'll have a basic understanding of how to use the SDK and where to look for more advanced use cases.
 
-### Install the Packages
+## Install the Packages
 
 First, create an empty directory and initialize it:
 ::: code-group
@@ -49,7 +49,7 @@ yarn add @alchemy/aa-alchemy @alchemy/aa-accounts @alchemy/aa-core viem
 
 :::
 
-### A Simple Light Account Example
+## A Simple Light Account Example
 
 Using the SDK, we'll create a Light Account and send a User Operation from it. The Light Account will be owned by an Externally Owned Account (EOA). Here's a demonstration:
 
@@ -62,13 +62,14 @@ Remember to:
 
 1. Replace `"0xYourEOAPrivateKey"` with your actual EOA private key.
 2. Set `"ALCHEMY_API_KEY"` with your unique Alchemy API key.
-3. Adjust the `target` and `data` fields in the `sendUserOperation` function to match your requirements.
+3. Fund your smart account address with some SepoliaETH in order for the user operation to go through. This address is logged to the console when you run the script.
+4. Adjust the `target` and `data` fields in the `sendUserOperation` function to match your requirements.
    :::
 
-### Dive Deeper
+## Dive Deeper
 
 In this guide we initialized `provider` with the `aa-alchemy` package however we could have done the same with the other packages of Account Kit as well. To learn more about the different packages and their use cases, check out the [packages overview](/packages/overview.html) page.
 
-### Next Steps
+## Next Steps
 
 To learn about the end-to-end process of integrating smart accounts in your applications check out the section on [using smart accounts](/smart-accounts/overview.html)

--- a/site/getting-started.md
+++ b/site/getting-started.md
@@ -68,7 +68,7 @@ Remember to:
 
 ## Dive Deeper
 
-In this guide we initialized `provider` with the `aa-alchemy` package however we could have done the same with the other packages of Account Kit as well. To learn more about the different packages and their use cases, check out the [packages overview](/packages/overview.html) page.
+In this guide we initialized `provider` with the `aa-alchemy` package however we could have done the same with the other packages of Account Kit as well. To learn more about the different packages and their use cases, check out the ["Packages Overview"](/packages/overview) page.
 
 ## Next Steps
 

--- a/site/getting-started.md
+++ b/site/getting-started.md
@@ -1,7 +1,66 @@
 ---
 outline: deep
+head:
+  - - meta
+    - property: og:title
+      content: Getting Started
+  - - meta
+    - name: description
+      content: Getting Started with Alchemy's Account Kit
+  - - meta
+    - property: og:description
+      content: Getting Started with Alchemy's Account Kit
 ---
 
 # Getting Started
+This guide will help you get started with Account Kit by setting up your environment, creating a Light Account (a type of smart account implementation), and sending a User Operation from it. By the end of this guide, you'll have a basic understanding of how to use the SDK and where to look for more advanced use cases.
 
-TODO
+### Install the Packages
+First, create an empty directory and initialize it:
+::: code-group
+```bash [npm]
+mkdir account-kit
+cd account-kit
+npm init -y
+```
+
+```bash [yarn]
+mkdir account-kit
+cd account-kit
+yarn init -y
+```
+:::
+
+Then you'll need to install the required packages:
+
+::: code-group
+```bash [npm]
+npm install @alchemy/aa-alchemy @alchemy/aa-accounts @alchemy/aa-core viem
+```
+
+```bash [yarn]
+yarn add @alchemy/aa-alchemy @alchemy/aa-accounts @alchemy/aa-core viem
+```
+:::
+
+### A Simple Light Account Example
+
+Using the SDK, we'll create a Light Account and send a User Operation from it. The Light Account will be owned by an Externally Owned Account (EOA). Here's a demonstration:
+
+<<< @/snippets/light-account.ts
+
+This initializes a `provider` for your smart account which is then used to send user operations from it. 
+
+
+::: tip Note
+Remember to:
+1. Replace `"0xYourEOAPrivateKey"` with your actual EOA private key.
+2. Set `"ALCHEMY_API_KEY"` with your unique Alchemy API key.
+3. Adjust the `target` and `data` fields in the `sendUserOperation` function to match your requirements.
+:::
+
+### Dive Deeper
+In this guide we initialized `provider` with the `aa-alchemy` package however we could have done the same with the other packages of Account Kit as well. To learn more about the different packages and their use cases, check out the [packages overview](/packages/overview.html) page.
+
+### Next Steps
+To learn about the end-to-end process of integrating smart accounts in your applications check out the section on [using smart accounts](/smart-accounts/overview.html)

--- a/site/getting-started.md
+++ b/site/getting-started.md
@@ -13,11 +13,14 @@ head:
 ---
 
 # Getting Started
+
 This guide will help you get started with Account Kit by setting up your environment, creating a Light Account (a type of smart account implementation), and sending a User Operation from it. By the end of this guide, you'll have a basic understanding of how to use the SDK and where to look for more advanced use cases.
 
 ### Install the Packages
+
 First, create an empty directory and initialize it:
 ::: code-group
+
 ```bash [npm]
 mkdir account-kit
 cd account-kit
@@ -29,11 +32,13 @@ mkdir account-kit
 cd account-kit
 yarn init -y
 ```
+
 :::
 
 Then you'll need to install the required packages:
 
 ::: code-group
+
 ```bash [npm]
 npm install @alchemy/aa-alchemy @alchemy/aa-accounts @alchemy/aa-core viem
 ```
@@ -41,6 +46,7 @@ npm install @alchemy/aa-alchemy @alchemy/aa-accounts @alchemy/aa-core viem
 ```bash [yarn]
 yarn add @alchemy/aa-alchemy @alchemy/aa-accounts @alchemy/aa-core viem
 ```
+
 :::
 
 ### A Simple Light Account Example
@@ -49,18 +55,20 @@ Using the SDK, we'll create a Light Account and send a User Operation from it. T
 
 <<< @/snippets/light-account.ts
 
-This initializes a `provider` for your smart account which is then used to send user operations from it. 
-
+This initializes a `provider` for your smart account which is then used to send user operations from it.
 
 ::: tip Note
 Remember to:
+
 1. Replace `"0xYourEOAPrivateKey"` with your actual EOA private key.
 2. Set `"ALCHEMY_API_KEY"` with your unique Alchemy API key.
 3. Adjust the `target` and `data` fields in the `sendUserOperation` function to match your requirements.
-:::
+   :::
 
 ### Dive Deeper
+
 In this guide we initialized `provider` with the `aa-alchemy` package however we could have done the same with the other packages of Account Kit as well. To learn more about the different packages and their use cases, check out the [packages overview](/packages/overview.html) page.
 
 ### Next Steps
+
 To learn about the end-to-end process of integrating smart accounts in your applications check out the section on [using smart accounts](/smart-accounts/overview.html)

--- a/site/snippets/light-account.ts
+++ b/site/snippets/light-account.ts
@@ -7,22 +7,23 @@ import { sepolia } from "viem/chains";
 const chain = sepolia;
 const PRIVATE_KEY = "0xYourEOAPrivateKey"; // Replace with the private key of your EOA that will be the owner of Light Account
 
-const eoaSigner: SmartAccountSigner = LocalAccountSigner.privateKeyToAccountSigner(PRIVATE_KEY); // Create a signer for your EOA
+const eoaSigner: SmartAccountSigner =
+  LocalAccountSigner.privateKeyToAccountSigner(PRIVATE_KEY); // Create a signer for your EOA
 
 // Create a provider with your EOA as the smart account owner, this provider is used to send user operations from your smart account and interact with the blockchain
 const provider = new AlchemyProvider({
-    apiKey: "ALCHEMY_API_KEY", // Replace with your Alchemy API key, you can get one at https://dashboard.alchemy.com/
-    chain,
-    entryPointAddress: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789", // EntryPoint address for Sepolia, replace if you're using a different entry point
+  apiKey: "ALCHEMY_API_KEY", // Replace with your Alchemy API key, you can get one at https://dashboard.alchemy.com/
+  chain,
+  entryPointAddress: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789", // EntryPoint address for Sepolia, replace if you're using a different entry point
 }).connect(
   (rpcClient) =>
-      new LightSmartContractAccount({
+    new LightSmartContractAccount({
       entryPointAddress: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
       chain: rpcClient.chain,
       owner: eoaSigner,
       factoryAddress: "0xDC31c846DA74400C732edb0fE888A2e4ADfBb8b1", // Factory address for Light Account on Sepolia
       rpcClient,
-  })
+    })
 );
 
 // Send a user operation from your smart contract account

--- a/site/snippets/light-account.ts
+++ b/site/snippets/light-account.ts
@@ -31,3 +31,5 @@ const { hash } = await provider.sendUserOperation({
   data: "0xCallData", // Replace with the desired call data
   value: 0n, // value: bigint or undefined
 });
+
+console.log(hash); // Log the user operation hash

--- a/site/snippets/light-account.ts
+++ b/site/snippets/light-account.ts
@@ -1,0 +1,33 @@
+// importing required dependencies
+import { AlchemyProvider } from "@alchemy/aa-alchemy";
+import { LightSmartContractAccount } from "@alchemy/aa-accounts";
+import { LocalAccountSigner, type SmartAccountSigner } from "@alchemy/aa-core";
+import { sepolia } from "viem/chains";
+
+const chain = sepolia;
+const PRIVATE_KEY = "0xYourEOAPrivateKey"; // Replace with the private key of your EOA that will be the owner of Light Account
+
+const eoaSigner: SmartAccountSigner = LocalAccountSigner.privateKeyToAccountSigner(PRIVATE_KEY); // Create a signer for your EOA
+
+// Create a provider with your EOA as the smart account owner, this provider is used to send user operations from your smart account and interact with the blockchain
+const provider = new AlchemyProvider({
+    apiKey: "ALCHEMY_API_KEY", // Replace with your Alchemy API key, you can get one at https://dashboard.alchemy.com/
+    chain,
+    entryPointAddress: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789", // EntryPoint address for Sepolia, replace if you're using a different entry point
+}).connect(
+  (rpcClient) =>
+      new LightSmartContractAccount({
+      entryPointAddress: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+      chain: rpcClient.chain,
+      owner: eoaSigner,
+      factoryAddress: "0xDC31c846DA74400C732edb0fE888A2e4ADfBb8b1", // Factory address for Light Account on Sepolia
+      rpcClient,
+  })
+);
+
+// Send a user operation from your smart contract account
+const { hash } = await provider.sendUserOperation({
+  target: "0xTargetAddress", // Replace with the desired target address
+  data: "0xCallData", // Replace with the desired call data
+  value: 0n, // value: bigint or undefined
+});

--- a/site/snippets/light-account.ts
+++ b/site/snippets/light-account.ts
@@ -26,6 +26,9 @@ const provider = new AlchemyProvider({
     })
 );
 
+// Logging the smart account address -- please fund this address with some SepoliaETH in order for the user operations to be executed successfully
+provider.getAddress().then((address: string) => console.log(address));
+
 // Send a user operation from your smart contract account
 const { hash } = await provider.sendUserOperation({
   target: "0xTargetAddress", // Replace with the desired target address


### PR DESCRIPTION
## PR Overview
- Adds a "Getting Started" page with code snippet for sending userops through Light Account.
- Re-order the pages on the left to move "Packages Overview" towards the end, after "Using Smart Accounts" section.

## Open Questions
- Should we provide a code snippet with actual values for `target`, `data` and `value` to send a user operation? Instead of leaving them with placeholders for user to add?
- If so, which factory address should we use for LightAccount? (as it's not final yet?)
- Currently the guide just gives the code snippet for a user to use LightAccount and send user ops, however, they would need to have some ETH in their smart account for this to work.
- Should we add a code snippet for determining the counterfactual address and asking them to send ETH to that address? Though, this comes at the cost of taking the simplicity of the guide away upto some extent and adds some resistance.
- Or should we use the Gas Manager in the same guide so they won't have to even have ETH in their account and can run it without any resistance? But again this comes at the cost of taking away simplicity of the guide away upto some extent as in this case, we would have to send a user operation that does some function interaction on a smart contract (instead of just a simple ETH transfer) 